### PR TITLE
Fixed crash when operator specified on integer field.  Added support for operators such as "<", ">=".  Added replace_row callback.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+*~

--- a/lib/wice/columns/column_integer.rb
+++ b/lib/wice/columns/column_integer.rb
@@ -35,6 +35,23 @@ module Wice
 
 
     class ConditionsGeneratorColumnInteger < ConditionsGeneratorColumn  #:nodoc:
+      def get_op_and_value( val )
+        num=nil
+        op=nil
+
+        # remove spaces
+        val = val.gsub(' ','')
+
+        first_digit_or_dot_index = val =~ /[0-9.]/
+        if first_digit_or_dot_index
+          op=val[0...first_digit_or_dot_index]
+          op='=' if op==''
+          num = Float(val[first_digit_or_dot_index..-1]) rescue nil
+        
+          op=nil unless ['<','>','<=','>=','='].include?(op)
+        end
+        [op, num]
+      end
 
       def  generate_conditions(table_alias, opts)   #:nodoc:
         unless opts.kind_of? Hash
@@ -43,9 +60,10 @@ module Wice
         end
         conditions = [[]]
         if opts[:eq]
-          if opts[:eq] =~ /\d/
-            conditions[0] << " #{@column_wrapper.alias_or_table_name(table_alias)}.#{@column_wrapper.name} = ? "
-            conditions << opts[:eq]
+          op, num = get_op_and_value( opts[:eq] )
+          if op && num
+            conditions[0] << " #{@column_wrapper.alias_or_table_name(table_alias)}.#{@column_wrapper.name} " + op + " ? "
+            conditions << num
           else
             opts.delete(:eq)
           end

--- a/lib/wice/grid_renderer.rb
+++ b/lib/wice/grid_renderer.rb
@@ -11,6 +11,7 @@ module Wice
     attr_reader :page_parameter_name
     attr_reader :after_row_handler
     attr_reader :before_row_handler
+    attr_reader :replace_row_handler
     attr_reader :blank_slate_handler
     attr_reader :last_row_handler
     attr_reader :grid
@@ -407,6 +408,12 @@ module Wice
     # Nothing is added if the block return +false+ or +nil+.
     def before_row(&block)
       @before_row_handler = block
+    end
+
+    # Can be used to replace the HTML code (for example to make a multi-column spanning row) of a row.
+    # Nothing is replaced if the block return +false+ or +nil+.
+    def replace_row(&block)
+      @replace_row_handler = block
     end
 
     # Can be used to add HTML code (calculation results, for example) after all rows.

--- a/lib/wice/memory_adapter.rb
+++ b/lib/wice/memory_adapter.rb
@@ -1,0 +1,172 @@
+# encoding: UTF-8
+module Wice
+  module MemoryAdapter
+    class MemoryAdapter
+      def initialize( rows, columns, kaminarafy=true )
+        @rows = rows
+        @klass = MemoryAdapterKlass.new(columns, self)
+        @columns=Set.new
+        columns.each do |col|
+          @columns << col.name.to_sym
+        end
+        @page_num=1
+        @per_page=20
+      end
+
+      def klass
+        @klass
+      end    
+
+      def total_count
+        length
+      end
+      
+      def length
+        @rows.length
+      end
+
+      # 1-based page number
+      def current_page
+        @page_num
+      end
+
+      def limit_value
+        @per_page
+      end
+
+      def total_pages
+        total_pages=(length.to_f / @per_page).ceil
+        total_pages
+      end
+
+      # 0-based index into array
+      def offset_value
+        @page_num = total_pages if current_page > total_pages
+            
+        offset_value = (current_page-1) * @per_page
+        offset_value
+      end
+
+      def num_pages
+        total_pages
+      end
+
+      def last_page?
+        last_page = current_page==total_pages
+        last_page
+      end
+
+      def includes(*opts)
+        self
+      end
+
+      def joins(*opts)
+        self
+      end
+
+      def order(*opts)
+        self
+      end
+
+      def where(*opts)
+        self
+      end
+
+      def page(num)
+        @page_num=num.to_i
+        @page_num =1 if @page_num < 1
+        self
+      end
+
+      def per(num)
+        @per_page=num.to_i
+        @per_page = 1 if @per_page < 1
+        self
+      end      
+
+      def each
+        start_index = offset_value
+        end_index = offset_value + @per_page
+        slice = @rows[start_index...end_index]
+        if slice
+          slice.each do |row|
+            yield Row.new(row, self)
+          end
+        end
+      end
+
+      def has_column?(col)
+        @columns.include?(col)
+      end
+    end
+
+    class MemoryAdapterKlass
+      def initialize( columns, memory_adapter )
+        @columns = columns
+        @memory_adapter = memory_adapter
+      end
+
+      def columns
+        @columns
+      end
+
+      def table_name
+        SecureRandom.hex
+      end
+
+      def merge_conditions(*conditions)
+        ""
+      end
+
+      def unscoped(&code)
+        #@memory_adapter.unscope
+        code.call
+        self
+      end
+
+      def connection
+      end
+    end
+
+    class Row
+      def initialize(row, memory_adapter)
+        @row=row
+        @memory_adapter = memory_adapter
+      end
+
+      def method_missing(m, *args, &block)
+        if @memory_adapter.has_column?(m)
+          @row[m]
+        else
+          super
+        end
+      end
+    end
+
+    class Column
+      def initialize(name)
+        @name = name.to_s
+        @model = Model.new
+      end
+
+      def name
+        @name
+      end
+      
+      def model
+        @model
+      end
+
+      def model=(model)
+        @model=model
+      end
+
+      def type
+        :string
+      end
+    end
+    
+    class Model
+    end
+  end
+end

--- a/lib/wice/wice_grid_controller.rb
+++ b/lib/wice/wice_grid_controller.rb
@@ -65,7 +65,6 @@ module Wice
     # can be changed in <tt>lib/wice_grid_config.rb</tt>, this is convenient if you want to set a project wide setting
     # without having to repeat it for every grid instance.
 
-
     def initialize_grid(klass, opts = {})
       wg = WiceGrid.new(klass, self, opts)
       self.wice_grid_instances = [] if self.wice_grid_instances.nil?


### PR DESCRIPTION
Operator filters are now supported for integer columns.  You can specify "< 3.2",">= 12", "=11", or just plain "11".

Fixed issue where rails threw an exception if a filter was specified such as "not a 3 number" or with an operator "< 12"

Added replace_row which is a callback like before_row or after_row.  It lets you specify the whole contents of a row, just in case you need to do something special like make a column that spans the whole row.
