### PR TITLE
allow user to set the kaminari page method

### DIFF
--- a/lib/generators/wice_grid/templates/wice_grid_config.rb
+++ b/lib/generators/wice_grid/templates/wice_grid_config.rb
@@ -166,4 +166,6 @@ if defined?(Wice::Defaults)
   # popup calendar will be shown relative to the popup trigger element or to the mouse pointer
   Wice::Defaults::POPUP_PLACEMENT_STRATEGY = :trigger # :pointer
 
+  # The name of the page method (should correspond to Kaminari.config.page_method_name)
+  Wice::Defaults::PAGE_METHOD_NAME = :page
 end

--- a/lib/wice_grid.rb
+++ b/lib/wice_grid.rb
@@ -106,6 +106,7 @@ module Wice
         :order                => nil,
         :order_direction      => Defaults::ORDER_DIRECTION,
         :page                 => 1,
+        :page_method_name     => Defaults::PAGE_METHOD_NAME,
         :per_page             => Defaults::PER_PAGE,
         :saved_query          => nil,
         :total_entries        => nil,
@@ -294,7 +295,7 @@ module Wice
         else
           # p @ar_options
           relation = @relation.
-            page(    @ar_options[:page]).
+            send(    @options[:page_method_name], @ar_options[:page]).
             per(     @ar_options[:per_page]).
             includes(@ar_options[:include]).
             joins(   @ar_options[:joins]).


### PR DESCRIPTION
So I'm trying to put wice_grid into an app that uses will_paginate.  Rather than changing everything over to kaminari (which might not be a bad idea), I'm trying to use both simultaneously.  Kaminari supports `config.page_method_name = <method_symbol>` that allows you to use a method other than `page` to do your paginatation.  I've set this up, but wice_grid expects the kaminari page method to be called `page`.  I suppose we could get the method from kamanari itself but I thought it might be simplest just to add an option to set the name of the `page` method, both in the defaults so it can be set at config time, as well as when setting up the grid (just because, really).  I can add tests if you like but I was not sure how to handle that since tests are in a different repo.  Thanks for your consideration and so far your gem is looking great.  I look forward to using it more.
