### PR TITLE
Turbolinks.visit support

### DIFF
--- a/lib/generators/wice_grid/templates/wice_grid_config.rb
+++ b/lib/generators/wice_grid/templates/wice_grid_config.rb
@@ -166,4 +166,6 @@ if defined?(Wice::Defaults)
   # popup calendar will be shown relative to the popup trigger element or to the mouse pointer
   Wice::Defaults::POPUP_PLACEMENT_STRATEGY = :trigger # :pointer
 
+  # The name of the page method (should correspond to Kaminari.config.page_method_name)
+  Wice::Defaults::PAGE_METHOD_NAME = :page
 end

--- a/lib/wice_grid.rb
+++ b/lib/wice_grid.rb
@@ -106,6 +106,7 @@ module Wice
         :order                => nil,
         :order_direction      => Defaults::ORDER_DIRECTION,
         :page                 => 1,
+        :page_method_name     => Defaults::PAGE_METHOD_NAME,
         :per_page             => Defaults::PER_PAGE,
         :saved_query          => nil,
         :total_entries        => nil,
@@ -294,7 +295,7 @@ module Wice
         else
           # p @ar_options
           relation = @relation.
-            page(    @ar_options[:page]).
+            send(    @options[:page_method_name], @ar_options[:page]).
             per(     @ar_options[:per_page]).
             includes(@ar_options[:include]).
             joins(   @ar_options[:joins]).

--- a/vendor/assets/javascripts/wice_grid_processor.js.coffee
+++ b/vendor/assets/javascripts/wice_grid_processor.js.coffee
@@ -12,8 +12,13 @@ class WiceGridProcessor
 
 
   process : (domIdToFocus)->
-    window.location = @buildUrlWithParams(domIdToFocus)
+    @visit @buildUrlWithParams(domIdToFocus)
 
+  visit : (path) ->
+    if Turbolinks?
+      Turbolinks.visit path
+    else
+      window.location = path
 
   setProcessTimer : (domIdToFocus)->
 
@@ -30,7 +35,7 @@ class WiceGridProcessor
 
   reloadPageForGivenGridState : (gridState)->
     requestPath = @gridStateToRequest(gridState)
-    window.location = @appendToUrl(@baseLinkForShowAllRecords, requestPath)
+    @visit @appendToUrl(@baseLinkForShowAllRecords, requestPath)
 
 
   gridStateToRequest : (gridState)->
@@ -75,11 +80,11 @@ class WiceGridProcessor
 
 
   reset : ->
-    window.location = @baseRequestForFilter
+    @visit @baseRequestForFilter
 
 
   exportToCsv : ->
-    window.location = @linkForExport
+    @visit @linkForExport
 
 
   register : (func)->

--- a/vendor/assets/javascripts/wice_grid_saved_queries_init.js.coffee
+++ b/vendor/assets/javascripts/wice_grid_saved_queries_init.js.coffee
@@ -25,7 +25,7 @@ loadQuery = (loadLink, event) ->
       gridProcessor.parameterNameForQueryLoading +  encodeURIComponent(queryId)
     )
 
-    window.location = request
+    gridProcessor.visit request
 
   event.preventDefault()
   event.stopPropagation()


### PR DESCRIPTION
It would be great if we could use `Turbolinks.visit` for auto_reload.  Here's some changes to that effect (they are built on top of my changes to pick the kaminari page method).  Again, no tests, because I wasn't sure what's going on with the separate test repo (seems like it would be hard to keep things in sync).

I put the visit method in the grid processor and made it public, which doesn't seem idle but it was the DRYest option.  Seems like it might be better for the clause that uses it in `wice_grid_saved_queries_init.js.coffee`, to just be moved to the grid processor and then visit could be a private method.
