### PR TITLE
rails4 asset pipeline support

### DIFF
--- a/lib/generators/wice_grid/templates/wice_grid.css.scss
+++ b/lib/generators/wice_grid/templates/wice_grid.css.scss
@@ -37,11 +37,11 @@
     }
 
     .collapse-multi-select-icon{
-      background: transparent url(/assets/icons/grid/collapse.gif) no-repeat;
+      background: transparent image-url("icons/grid/collapse.gif") no-repeat;
     }
 
     .expand-multi-select-icon{
-      background: transparent url(/assets/icons/grid/expand.gif) no-repeat;
+      background: transparent image-url("icons/grid/expand.gif") no-repeat;
     }
 
   }
@@ -56,43 +56,43 @@
   }
 
   .desc {
-    background: transparent url(/assets/icons/grid/arrow_down.gif) right no-repeat
+    background: transparent image-url("icons/grid/arrow_down.gif") right no-repeat
   }
   .asc  {
-    background: transparent url(/assets/icons/grid/arrow_up.gif)   right no-repeat
+    background: transparent image-url("icons/grid/arrow_up.gif")   right no-repeat
   }
 
   .submit.clickable{
-    background: transparent url(/assets/icons/grid/table_refresh.png) no-repeat;
+    background: transparent image-url("icons/grid/table_refresh.png") no-repeat;
     @include icon-dimensions;
   }
 
   .reset.clickable{
-    background: transparent url(/assets/icons/grid/table.png) no-repeat;
+    background: transparent image-url("icons/grid/table.png") no-repeat;
     @include icon-dimensions;
   }
 
 
   .wg-show-filter.clickable,
   .wg-hide-filter.clickable{
-    background: transparent url(/assets/icons/grid/page_white_find.png) no-repeat;
+    background: transparent image-url("icons/grid/page_white_find.png") no-repeat;
     @include icon-dimensions;
   }
 
 
   .export-to-csv-button.clickable{
-    background: transparent url(/assets/icons/grid/page_white_excel.png) no-repeat;
+    background: transparent image-url("icons/grid/page_white_excel.png") no-repeat;
     @include icon-dimensions;
   }
 
   .clickable.select-all{
-    background: transparent url(/assets/icons/grid/tick_all.png) no-repeat;
+    background: transparent image-url("icons/grid/tick_all.png") no-repeat;
     @include icon-dimensions;
     float:left;
   }
 
   .clickable.deselect-all{
-    background: transparent url(/assets/icons/grid/untick_all.png) no-repeat;
+    background: transparent image-url("icons/grid/untick_all.png") no-repeat;
     @include icon-dimensions;
     float:left;
   }
@@ -126,7 +126,7 @@
   ul {margin-left: 0 }
 
   a.wice-grid-delete-query .delete-icon{
-    background: transparent url(/assets/icons/grid/delete.png) no-repeat;
+    background: transparent image-url("icons/grid/delete.png") no-repeat;
     float: left;
     @include icon-dimensions;
   }

--- a/lib/wice_grid.rb
+++ b/lib/wice_grid.rb
@@ -52,6 +52,10 @@ module Wice
         require 'wice/kaminari_monkey_patching.rb'
       end
     end
+
+    initializer "wice_grid_railtie.configure_rails_assets_precompilation" do |app|
+      app.config.assets.precompile << 'icons/grid/*'
+    end
   end
 
   class WiceGrid


### PR DESCRIPTION
Thanks for grabbing my last pull requests.  I'm not sure I've got this one quite right (because to do that I'd have to fully understand the rails asset pipeline and sprockets and I think there may be only one or two people in the whole world like that.  ;).

So what I'm doing here is using the image-url helpers so that I get a fingerprinted asset name, and I'm explicitly adding the wice_grid assets to the precompile list so that they are generated.  I'm using rails4 and I had trouble in production with the assets because rails4 no longer automatically precompiles assets from vendor gems.  I've been looking for some online guidance that tells all gem owners with image assets that they should be explicitly precompiling their assets and using the image-url helper to ensure that (a) they get fingerprinted assets and (b) their css is dependent on those fingerprints (I think image-url implicitly creates this dependency, but I could be wrong).  I haven't found anything explicitly saying all this, but that's my takeaway from what I've read.
