### PR TITLE
change how relations are detect so that it can work with proxies

### DIFF
--- a/lib/wice_grid.rb
+++ b/lib/wice_grid.rb
@@ -71,9 +71,9 @@ module Wice
       @controller = controller
 
       @relation = klass_or_relation
-      @klass = klass_or_relation.is_a?(ActiveRecord::Relation) ?
-        klass_or_relation.klass :
-        klass_or_relation
+      @klass = klass_or_relation.kind_of?(ActiveRecord::Base) ?
+        klass_or_relation :
+        klass_or_relation.klass
 
       unless @klass.kind_of?(Class) && @klass.ancestors.index(ActiveRecord::Base)
         raise WiceGridArgumentError.new("ActiveRecord model class (second argument) must be a Class derived from ActiveRecord::Base")


### PR DESCRIPTION
This is a very minor change that doesn't require an ActiveRecord::Relation to be passed to initialize grid.  Instead it checks to see if the class is a child of ActiveRecord::Base.  I needed this for my app after adding the octopus gem for db sharding because the octopus returns a proxy for activerecord relations that is not actually an ActiveRecord::Relation.  Could be this just moves the problem somewhere else but I think it's a good bet, that if you're passing an actual model class, that it really will be a class and not some sort of proxy.  Thanks for your consideration of this.
