### PR TITLE
add missing support for the :group ar_options

### DIFF
--- a/lib/wice/helpers/wice_grid_view_helpers.rb
+++ b/lib/wice/helpers/wice_grid_view_helpers.rb
@@ -659,7 +659,7 @@ module Wice
 
       if grid.all_record_mode?
 
-        collection_total_entries = collection.size
+        collection_total_entries = collection.length
         current_page = 1
         per_page = collection_total_entries
 

--- a/lib/wice_grid.rb
+++ b/lib/wice_grid.rb
@@ -289,6 +289,7 @@ module Wice
             includes(@ar_options[:include]).
             joins(   @ar_options[:joins]).
             order(   @ar_options[:order]).
+            group(   @ar_options[:group]).
             where(   @ar_options[:conditions])
 
         else
@@ -299,6 +300,7 @@ module Wice
             includes(@ar_options[:include]).
             joins(   @ar_options[:joins]).
             order(   @ar_options[:order]).
+            group(   @ar_options[:group]).
             where(   @ar_options[:conditions])
 
         end


### PR DESCRIPTION
fixes #170 
when showing pagination - all records we have to use the length method so that
we get the size of the array ( for group we would get a hash with grouped counts)
