### PR TITLE
Fix CSV export when filtering on an association

### DIFF
--- a/lib/wice_grid.rb
+++ b/lib/wice_grid.rb
@@ -304,13 +304,15 @@ module Wice
       form_ar_options
       @klass.unscoped do
         @resultset = if self.output_csv? || all_record_mode?
-          @relation.
+          relation = @relation.
             includes(@ar_options[:include]).
             joins(   @ar_options[:joins]).
             order(   @ar_options[:order]).
             group(   @ar_options[:group]).
             where(   @ar_options[:conditions])
-
+          relation = add_references relation
+          
+          relation
         else
           # p @ar_options
           relation = @relation.


### PR DESCRIPTION
It seems like the `includes` don't get carried over when exporting to CSV. This amendment does fix this problem by calling add_references and returning the relation when it is a CSV export - the same code as with the non-export.
