### PR TITLE
Make language more gender-neutral

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -17,7 +17,7 @@ For rails 2 use the +master+ branch:  https://github.com/leikind/wice_grid/tree/
 
 WiceGrid is a Rails grid plugin.
 
-One of the goals of this plugin was to allow the programmer to define the contents of the cell by himself,
+One of the goals of this plugin was to allow the programmer to define the contents of the cell on their own,
 just like one does when rendering a collection via a simple table (and this is what differentiates WiceGrid
 from various scaffolding solutions), but automate implementation of filters, ordering, paginations,
 CSV export, and so on. Ruby blocks provide an elegant means for this.

--- a/wice_grid.gemspec
+++ b/wice_grid.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.date          = '2015-03-01'
   s.summary       = 'A Rails grid plugin to create grids with sorting, pagination, and (automatically generated) filters.'
   s.description   = 'A Rails grid plugin to create grids with sorting, pagination, and (automatically generated) filters.' +
-                    'One of the goals of this plugin was to allow the programmer to define the contents of the cell by himself, '  +
+                    'One of the goals of this plugin was to allow the programmer to define the contents of the cell on their own, '  +
                     'just like one does when rendering a collection via a simple table (and this is what differentiates WiceGrid ' +
                     'from various scaffolding solutions), but automate implementation of filters, ordering, paginations, CSV '     +
                     'export, and so on. Ruby blocks provide an elegant means for this.'


### PR DESCRIPTION
This is a small tweak to make the descriptive language of this repo more gender-neutral. This is easy to do in English by changing he or she to 'they' and himself or herself to 'themselves' (a plural form is used as the singular and sounds natural to native speakers).

I also tweaked the wording stylistically. My tweak also retains the ambiguity of the original text. :wink: 
