### PR TITLE
filterDeclaration can sometimes be null, esp for Time datatypes

### DIFF
--- a/vendor/assets/javascripts/wice_grid_init.js.coffee
+++ b/vendor/assets/javascripts/wice_grid_init.js.coffee
@@ -22,11 +22,12 @@ initWiceGrid = ->
 
     for filterDeclaration in filterDeclarations
       do (filterDeclaration) ->
-        gridProcessor.register
-          filterName : filterDeclaration.filterName
-          detached    : filterDeclaration.detached
-          templates   : filterDeclaration.declaration.templates
-          ids         : filterDeclaration.declaration.ids
+        if filterDeclaration?
+          gridProcessor.register
+            filterName : filterDeclaration.filterName
+            detached    : filterDeclaration.detached
+            templates   : filterDeclaration.declaration.templates
+            ids         : filterDeclaration.declaration.ids
 
     unless window[globalVarForAllGrids]
       window[globalVarForAllGrids] = {}


### PR DESCRIPTION
In my grid, I have a column which has a Time data type.  In this scenario, the javascript breaks, because the `filterDeclaration` variable is null - presumably because wice_grid supports DateTime and Dates, but not Times for columns.

This fixes the javascript error, which is important, because this javascript error prevents everything else from working (any of the filters, the 'show all link', the export to CSV - they all break).

I guess there is still the issue of no time filter being present, but that can be fixed later. For now, this at least lets the grid work as before.
