### PR TITLE
Quote Postgres table names with schema. Fixes leikind/wice_grid#154

### DIFF
--- a/lib/wice_grid.rb
+++ b/lib/wice_grid.rb
@@ -522,7 +522,9 @@ module Wice
       end
 
       if custom_order.blank?
-        if ActiveRecord::ConnectionAdapters.const_defined?(:SQLite3Adapter) && ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::SQLite3Adapter)
+        sqlite = ActiveRecord::ConnectionAdapters.const_defined?(:SQLite3Adapter) && ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::SQLite3Adapter)
+        postgres = ActiveRecord::ConnectionAdapters.const_defined?(:PostgreSQLAdapter) && ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+        if sqlite || postgres
           fully_qualified_column_name.strip.split('.').map{|chunk| ActiveRecord::Base.connection.quote_table_name(chunk)}.join('.')
         else
           ActiveRecord::Base.connection.quote_table_name(fully_qualified_column_name.strip)


### PR DESCRIPTION
"car.color".strip.split('.').map{|chunk| ActiveRecord::Base.connection.quote_table_name(chunk)}.join('.')
=> "\"car\".\"color\""

"public.car.color".strip.split('.').map{|chunk| ActiveRecord::Base.connection.quote_table_name(chunk)}.join('.')
=> "\"public\".\"car\".\"color\""
