### PR TITLE
Quoting schema-qualified tables. Fixes leikind/wice_grid#154.

### DIFF
--- a/lib/wice_grid.rb
+++ b/lib/wice_grid.rb
@@ -543,7 +543,9 @@ module Wice
       end
 
       if custom_order.blank?
-        if ActiveRecord::ConnectionAdapters.const_defined?(:SQLite3Adapter) && ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::SQLite3Adapter)
+        sqlite = ActiveRecord::ConnectionAdapters.const_defined?(:SQLite3Adapter) && ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::SQLite3Adapter)
+        postgres = ActiveRecord::ConnectionAdapters.const_defined?(:PostgreSQLAdapter) && ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+        if sqlite || postgres
           fully_qualified_column_name.strip.split('.').map { |chunk| ActiveRecord::Base.connection.quote_table_name(chunk) }.join('.')
         else
           ActiveRecord::Base.connection.quote_table_name(fully_qualified_column_name.strip)


### PR DESCRIPTION
The problem:

```
  ActiveRecord::Base.connection.quote_table_name("public.car.color")
  => "public"."car"  
```

Notice the ".color" is missing. I think the issue is using quote__table__name to quote a _column_ name.

The quick fix is to quote each chunk like is done with Sqlite

```
  "car.color".strip.split('.').map{|chunk| ActiveRecord::Base.connection.quote_table_name(chunk)}.join('.')
  => "car"."color"

  "public.car.color".strip.split('.').map{|chunk| ActiveRecord::Base.connection.quote_table_name(chunk)}.join('.')
  => "public"."car"."color"
```

A better cross-database fix is probably to split on the last period and use `quote_table_name` / `quote_column_name` on each half.
