### PR TITLE
ForbiddenAttributeError when using :extra_parameters fix

### DIFF
--- a/lib/wice/wice_grid_serialized_queries_controller.rb
+++ b/lib/wice/wice_grid_serialized_queries_controller.rb
@@ -52,7 +52,7 @@ module Wice
       @saved_query.name      = params[:query_name]
       @saved_query.query     = query_params
 
-      @saved_query.attributes = params[:extra] unless params[:extra].blank?
+      @saved_query.attributes = extra unless extra.nil?
 
       if @saved_query.save
         @grid_title_id = "#{@grid_name}_title"
@@ -65,7 +65,7 @@ module Wice
     end
 
     def extra #:nodoc:
-      params[:extra]
+      params[:extra].permit! unless params[:extra].nil?
     end
 
     protected


### PR DESCRIPTION
Hello!

Recently I encountered a problem when trying to create saved_querries per user. I fallowed the instructions from here: https://github.com/leikind/wice_grid/blob/rails3/SAVED_QUERIES_HOWTO.md

But after all I saw:

``` ruby
ActiveModel::ForbiddenAttributesError (ActiveModel::ForbiddenAttributesError):
  activemodel (4.2.3) lib/active_model/forbidden_attributes_protection.rb:21:in `sanitize_for_mass_assignment'
```

I tracked that it complained because of mass attribute assigment using 'raw' parameters. I prepared a simple fix. Comments are welcomed.

Regards,
Michał
