### PR TITLE
Ukrainian locale doesn't work without quotes

### DIFF
--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -5,41 +5,41 @@ uk:
       - :month
       - :day
   wice_grid:
-    show_filter_tooltip: Показати фільтр
-    hide_filter_tooltip: Сховати фільтр
-    csv_export_tooltip: Експорт в CSV
-    filter_tooltip: Фільтрувати
-    reset_filter_tooltip: Скинути фільтр
-    boolean_filter_true_label: так
-    boolean_filter_false_label: ні
-    previous_label: «
-    next_label: »
+    show_filter_tooltip: "Показати фільтр"
+    hide_filter_tooltip: "Сховати фільтр"
+    csv_export_tooltip: "Експорт в CSV"
+    filter_tooltip: "Фільтрувати"
+    reset_filter_tooltip: "Скинути фільтр"
+    boolean_filter_true_label: "так"
+    boolean_filter_false_label: "ні"
+    previous_label: "«"
+    next_label: "»"
     # Title of the icon clicking on which will show the calendar to set the FROM date.
-    date_selector_tooltip_from: Від
+    date_selector_tooltip_from: "Від"
     # Title of the icon clicking on which will show the calendar to set the TO date.
-    date_selector_tooltip_to: До
+    date_selector_tooltip_to: "До"
     # The title of the checkox to turn on negation
-    negation_checkbox_title: За винятком
+    negation_checkbox_title: "За винятком"
     # link to switch to show all records
-    show_all_records_label: показати всі
+    show_all_records_label: "показати всі"
     # tooltip for the link to switch to show all records
-    show_all_records_tooltip: Показати всі записи
+    show_all_records_tooltip: "Показати всі записи"
     # Warning message shown when the user wants to switch to all-records mode
-    all_queries_warning: Ви впевнені в тому, що хочете відобразити всі записи?
+    all_queries_warning: "Ви впевнені в тому, що хочете відобразити всі записи?"
     # link to paginated view
-    switch_back_to_paginated_mode_label: Назад до посторінкового виводу
+    switch_back_to_paginated_mode_label: "Назад до посторінкового виводу"
     # tooltip for the link to paginated view
-    switch_back_to_paginated_mode_tooltip: Назад до посторінкового виводу
+    switch_back_to_paginated_mode_tooltip: "Назад до посторінкового виводу"
     # Title of the date string.
-    date_string_tooltip: Натисніть, щоб видалити дату
-    saved_query_panel_title: Збережені фільтри
-    save_query_button_label: Зберегти фільтр
-    saved_query_deletion_confirmation: Ви впевнені?
-    saved_query_deletion_link_title: Видалити збережуваний фільтр
-    saved_query_link_title: Завантажити збережуваний фільтр
-    validates_uniqueness_error: Збережуваний фільтр з такою назвою вже існує
-    validates_presence_error: Будь ласка, введіть назву Збережуваного фільтра
-    query_deleted_message: Збережуваний фільтр видалено.
-    query_saved_message: Збережуваний фільтр збережено.
-    select_all: Виділити все
-    deselect_all: Забрати виділення
+    date_string_tooltip: "Натисніть, щоб видалити дату"
+    saved_query_panel_title: "Збережені фільтри"
+    save_query_button_label: "Зберегти фільтр"
+    saved_query_deletion_confirmation: "Ви впевнені?"
+    saved_query_deletion_link_title: "Видалити збережуваний фільтр"
+    saved_query_link_title: "Завантажити збережуваний фільтр"
+    validates_uniqueness_error: "Збережуваний фільтр з такою назвою вже існує"
+    validates_presence_error: "Будь ласка, введіть назву Збережуваного фільтра"
+    query_deleted_message: "Збережуваний фільтр видалено."
+    query_saved_message: "Збережуваний фільтр збережено."
+    select_all: "Виділити все"
+    deselect_all: "Забрати виділення"


### PR DESCRIPTION
Cyrillic symbols need to be in quotes. Sorry, did't remembered about it before.
