### PR TITLE
replaces old version of Style/TrailingComma with Style/TrailingCommaI…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,11 +19,16 @@ Style/SpaceAroundBlockParameters:
 
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleForMultiline, SupportedStyles.
-Style/TrailingComma:
-  Enabled: true
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: no_comma
 
 # Cop supports --auto-correct.
-Style/SingleSpaceBeforeFirstArg:
+# Configuration parameters: EnforcedStyleForMultiline, SupportedStyles.
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: no_comma
+
+# Cop supports --auto-correct.
+Style/SpaceBeforeFirstArg:
   Enabled: true
 
 # Cop supports --auto-correct.


### PR DESCRIPTION
…nArguments and Style/TrailingCommaInLiteral. Also replaces Style/SingleSpaceBeforeFirstArg with Style/SpaceBeforeFirstArg

I was getting warnings about depreciation warnings. This fixes those and I assumed sensible defaults. 
