### PR TITLE
fixes autofiltering cursor position bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 3.6.3
+
+### Focused Filter Has Cursor/Caret at the End of Input
+
+The cursor/caret used to appear at the beginning of the focused autocomplete in FF and IE.
+This caused annoyances for users of those browsers who typed slowly since the page would
+reload and when they startd typing again the text would appear before their last entries.
+
+For example if someone was searching for 'john' but paused after 'joh', they would end up typing 'njoh', instead of 'john'. If they weren't paying attention,
+they might think there is no 'john', when they'd mistakenly searched for 'njoh'.
+
 # 3.6.0
 
 ## New API For Joined Tables

--- a/vendor/assets/javascripts/wice_grid_init.js.coffee
+++ b/vendor/assets/javascripts/wice_grid_init.js.coffee
@@ -205,13 +205,24 @@ setupSubmitReset = (wiceGridContainer, gridProcessor) ->
       event.preventDefault()
       gridProcessor.process()
 
+SetEnd = (txt) ->
+  if txt.createTextRange
+    #IE
+    FieldRange = txt.createTextRange()
+    FieldRange.moveStart 'character', txt.value.length
+    FieldRange.collapse()
+    FieldRange.select()
+  else
+    #Firefox and Opera
+    txt.focus()
+    length = txt.value.length
+    txt.setSelectionRange length, length
+  return
 
 focusElementIfNeeded = (focusId) ->
   elements = $('#' + focusId)
   if elToFocus = elements[0]
-    elToFocus.value = elToFocus.value
-    elToFocus.focus()
-
+    SetEnd elToFocus
 
 # autoreload for internal filters
 setupAutoreloadsForInternalFilters = (wiceGridContainer, gridProcessor) ->

--- a/wice_grid.gemspec
+++ b/wice_grid.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'wice_grid'
-  s.version       = '3.6.2'
+  s.version       = '3.6.3'
   s.authors       = ['Yuri Leikind and contributors']
   s.email         = ['yuri.leikind@gmail.com']
   s.homepage      = 'https://github.com/leikind/wice_grid'


### PR DESCRIPTION
The cursor/caret used to appear at the beginning of the focused autocomplete in FF and IE.
This caused annoyances for users of those browsers who typed slowly since the page would
reload and when they startd typing again the text would appear before their last entries.

For example if someone was searching for 'john' but paused after 'joh', they would end up typing 'njoh', instead of 'john'. If they weren't paying attention, they might think there is no 'john', when they'd mistakenly searched for 'njoh'.
