### PR TITLE
Fixes #to_query in grid_renderer for Rails 5:

### DIFF
--- a/lib/wice/grid_renderer.rb
+++ b/lib/wice/grid_renderer.rb
@@ -586,7 +586,7 @@ module Wice
 
       query_params = Wice::WgHash.rec_merge(cleaned_params, query_params)
 
-      '?' + query_params.to_query
+      '?' + query_params.to_h.to_query
     end
 
     protected


### PR DESCRIPTION
- fixes ActionView::Template::Error: wrong number of arguments (given 0, expected 1)
- to_query is called on an ActionController::Parameters object. Should be called on a hash
- quick fix until Rails 5.1: In Rails 5.1 ActionController::Parameters has no method to_h
