### PR TITLE
to_h leaves empty sorting headers in Rails 4

### DIFF
--- a/lib/wice/grid_renderer.rb
+++ b/lib/wice/grid_renderer.rb
@@ -586,7 +586,11 @@ module Wice
 
       query_params = Wice::WgHash.rec_merge(cleaned_params, query_params)
 
-      '?' + query_params.to_h.to_query
+      if rails.version.to_i >= 5
+        '?' + query_params.to_h.to_query
+      else
+        '?' + query_params.to_query
+      end
     end
 
     protected

--- a/lib/wice/grid_renderer.rb
+++ b/lib/wice/grid_renderer.rb
@@ -586,7 +586,7 @@ module Wice
 
       query_params = Wice::WgHash.rec_merge(cleaned_params, query_params)
 
-      if rails.version.to_i >= 5
+      if Rails.version.to_i >= 5
         '?' + query_params.to_h.to_query
       else
         '?' + query_params.to_query

--- a/lib/wice_grid.rb
+++ b/lib/wice_grid.rb
@@ -95,7 +95,7 @@ module Wice
         end
       end
 
-      opts[:order_direction].downcase! if opts[:order_direction].is_a?(String)
+      opts[:order_direction] = opts[:order_direction].downcase if opts[:order_direction].is_a?(String)
 
       # validate :order_direction
       if opts[:order_direction] && ! (opts[:order_direction] == 'asc' || opts[:order_direction] == :asc || opts[:order_direction] == 'desc' ||


### PR DESCRIPTION
Hey Yuri,
we're using rails 4.2.5.2. The commit from 'Philipp Großelfinger' leaves our sorting headers empty.
(`http://localhost:3000/tasks?`)

In our Version it just works without the .to_h method. 
I hope this pull request is ok. 

Greetings Yves

PS.: No Idea, why the opts[:order_direction] line is in there again.
