### PR TITLE
[Rails5] Fixes for ActionDispatch::Routing::INSECURE_URL_PARAMETERS_MESSAGE

### DIFF
--- a/lib/wice/grid_renderer.rb
+++ b/lib/wice/grid_renderer.rb
@@ -536,7 +536,7 @@ module Wice
     end
 
     def base_link_for_filter(controller, extra_parameters = {})   #:nodoc:
-      new_params = Wice::WgHash.deep_clone controller.params
+      new_params = Wice::WgHash.deep_clone controller.params.to_h
       new_params.merge!(extra_parameters)
 
       if new_params[@grid.name]
@@ -556,7 +556,7 @@ module Wice
     end
 
     def link_for_export(controller, format, extra_parameters = {})   #:nodoc:
-      new_params = Wice::WgHash.deep_clone controller.params
+      new_params = Wice::WgHash.deep_clone controller.params.to_h
       new_params.merge!(extra_parameters)
 
       new_params[@grid.name] = {} unless new_params[@grid.name]
@@ -578,7 +578,7 @@ module Wice
         ORDER_DIRECTION_PARAMETER_NAME => direction
       } }
 
-      cleaned_params = Wice::WgHash.deep_clone params
+      cleaned_params = Wice::WgHash.deep_clone params.to_h
       cleaned_params.merge!(extra_parameters)
 
       cleaned_params.delete(:controller)


### PR DESCRIPTION
While migrating my app to Rails 5  I encountered on ActionDispatch::Routing exception. This PR removes the deprecation warnings associated with the merge! method. It also removes the ActionDispatch::Routing exception. The exact message of the exception is "

> Attempting to generate a URL from non-sanitized request parameters! An attacker can inject malicious data into the generated URL, such as changing the host. Whitelist and sanitize passed parameters to be secure."

  The problem is present due to changes to ActionController::Parameters in Rails 5. 

Excerpt from the framework calls

> actionpack (5.0.0) lib/action_dispatch/routing/url_for.rb:176:in `url_for'
> /home/pfurman/.rvm/gems/ruby-2.3.1@rails5/bundler/gems/wice_grid-f3d6c462af2b/lib/wice/grid_renderer.rb:550:in`base_link_for_filter'
> /home/pfurman/.rvm/gems/ruby-2.3.1@rails5/bundler/gems/wice_grid-f3d6c462af2b/lib/wice/helpers/wice_grid_view_helpers.rb:471:in `grid_html'
> /home/pfurman/.rvm/gems/ruby-2.3.1@rails5/bundler/gems/wice_grid-f3d6c462af2b/lib/wice/helpers/wice_grid_view_helpers.rb:124:in`define_grid'
> actionview (5.0.0) lib/action_view/template.rb:158:in `block in render'
