### PR TITLE
Turbolinks 5 Support: Initialize WiceGrid on `turbolinks:render`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ reload and when they startd typing again the text would appear before their last
 For example if someone was searching for 'john' but paused after 'joh', they would end up typing 'njoh', instead of 'john'. If they weren't paying attention,
 they might think there is no 'john', when they'd mistakenly searched for 'njoh'.
 
+### Turbolinks 5 Support
+Handled by initializing WiceGrid on `turbolinks:render` as well as `page:load ready`
+
 # 3.6.0
 
 ## New API For Joined Tables

--- a/vendor/assets/javascripts/wice_grid_init.js.coffee
+++ b/vendor/assets/javascripts/wice_grid_init.js.coffee
@@ -1,4 +1,5 @@
 $(document).on 'page:load ready', -> initWiceGrid()
+$(document).on 'turbolinks:render', -> initWiceGrid()
 
 globalVarForAllGrids = 'wiceGrids'
 


### PR DESCRIPTION
Fixes #313 

For reference:
[Turbolinks full list of events](https://github.com/turbolinks/turbolinks#full-list-of-events)

`
turbolinks:render fires after Turbolinks renders the page. This event fires twice during an application visit to a cached location: once after rendering the cached version, and again after rendering the fresh version.
`