### PR TITLE
Fix Rails 5 deprecation of calling to_h on ActionController::Parameters

### DIFF
--- a/lib/wice_grid.rb
+++ b/lib/wice_grid.rb
@@ -574,7 +574,11 @@ module Wice
     end
 
     def this_grid_params  #:nodoc:
-      params[name]
+      if params.respond_to?(:to_unsafe_h)
+        params[name].to_unsafe_h
+      else
+        params[name]
+      end
     end
 
     def resultset_without_paging_without_user_filters  #:nodoc:


### PR DESCRIPTION
Fixes `DEPRECATION WARNING: Method to_hash is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.1/classes/ActionController/Parameters.html (called from process_params at vendor/bundle/ruby/2.4.0/bundler/gems/wice_grid-b304f95ab30d/lib/wice_grid.rb:219)`