### PR TITLE
Fix undefined method `to_unsafe_h' for nil:NilClass

### DIFF
--- a/lib/wice_grid.rb
+++ b/lib/wice_grid.rb
@@ -574,11 +574,7 @@ module Wice
     end
 
     def this_grid_params  #:nodoc:
-      if params.respond_to?(:to_unsafe_h)
-        params[name].to_unsafe_h
-      else
-        params[name]
-      end
+      params[name].try(:to_unsafe_h) || params[name]
     end
 
     def resultset_without_paging_without_user_filters  #:nodoc:


### PR DESCRIPTION
Oops, apparently I failed in my previous PR (https://github.com/leikind/wice_grid/pull/340). Instead of giving a deprecation warning, WiceGrid now crashes on Rails 5 when having no filters. Since this does not seem desired behaviour, or at least is not desired by me, I have updated my fix. My apologies for the inconvenience.