### PR TITLE
Use turbolinks:load as documented

### DIFF
--- a/vendor/assets/javascripts/wice_grid_init.js.coffee
+++ b/vendor/assets/javascripts/wice_grid_init.js.coffee
@@ -1,5 +1,4 @@
-$(document).on 'page:load ready', -> initWiceGrid()
-$(document).on 'turbolinks:render', -> initWiceGrid()
+$(document).on 'turbolinks:load', -> initWiceGrid()
 
 globalVarForAllGrids = 'wiceGrids'
 


### PR DESCRIPTION
The grid column filter requires the page to be refreshed on a Rails 4.2.8 project.

Loading Turbolinks via the `turbolinks:load` handler fixes this problem.

https://github.com/turbolinks/turbolinks#running-javascript-when-a-page-loads