### PR TITLE
Fix undefined method `tag_options' in Rails 5.1.

### DIFF
--- a/lib/wice/wice_grid_core_ext.rb
+++ b/lib/wice/wice_grid_core_ext.rb
@@ -113,7 +113,12 @@ module ActionView #:nodoc:
   module Helpers #:nodoc:
     module TagHelper #:nodoc:
       def public_tag_options(options, escape = true) #:nodoc:
-        tag_options(options, escape)
+        if respond_to?(:tag_options)
+          tag_options(options, escape)
+        # Rails 5.1 uses TagBuilder
+        else
+          tag_builder.tag_options(options, escape)
+        end
       end
     end
   end


### PR DESCRIPTION
Rails 5.1 moved tag_options() to ActionView::Helpers::TagBuilder.