### PR TITLE
Suitable for use on version 6 rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Coverage Status](https://coveralls.io/repos/leikind/wice_grid/badge.svg?branch=development&service=github)](https://coveralls.io/github/leikind/wice_grid?branch=development)
 -->
 
-THE PROJECT IS LOOKING FOR CONTRIBUTORS. THE AUTHOR WILL NOT WORK ON IT ANYMORE!
+Please use [the active Rails 5 only fork of the plugin](https://github.com/patricklindsay/wice_grid)
 
 * Yuri Leikind, yuri.leikind at gmail dot com
 * Version 3.6.0.pre3; [What's New In 3.6.0](https://github.com/leikind/wice_grid/wiki/What's-New-In-3.6.0)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+Please use [this active Rails 5 only fork of the plugin](https://github.com/patricklindsay/wice_grid)!
+
+_______
+
 [![Version](http://img.shields.io/gem/v/wice_grid.svg)](https://rubygems.org/gems/wice_grid)
 [![Build](https://travis-ci.org/leikind/wice_grid.svg)](https://travis-ci.org/leikind/wice_grid)
 [![Inline docs](http://inch-ci.org/github/leikind/wice_grid.svg?branch=rails3)](http://inch-ci.org/github/leikind/wice_grid/branch/rails3)
@@ -6,8 +10,6 @@
 <!-- let's disable for a while ;-)
 [![Coverage Status](https://coveralls.io/repos/leikind/wice_grid/badge.svg?branch=development&service=github)](https://coveralls.io/github/leikind/wice_grid?branch=development)
 -->
-
-Please use [the active Rails 5 only fork of the plugin](https://github.com/patricklindsay/wice_grid)
 
 * Yuri Leikind, yuri.leikind at gmail dot com
 * Version 3.6.0.pre3; [What's New In 3.6.0](https://github.com/leikind/wice_grid/wiki/What's-New-In-3.6.0)

--- a/lib/wice/wice_grid_core_ext.rb
+++ b/lib/wice/wice_grid_core_ext.rb
@@ -113,7 +113,7 @@ module ActionView #:nodoc:
   module Helpers #:nodoc:
     module TagHelper #:nodoc:
       def public_tag_options(options, escape = true) #:nodoc:
-        tag_options(options, escape)
+        tag_builder.tag_options(options, escape)
       end
     end
   end


### PR DESCRIPTION
The tag_options was deprecated in the rails 6 version to make the gem suitable for use with rails 6 I added the tag_builder.