### PR TITLE
Adds support for Rails 7.1

### DIFF
--- a/lib/wice/wice_grid_serialized_query.rb
+++ b/lib/wice/wice_grid_serialized_query.rb
@@ -1,5 +1,5 @@
 class WiceGridSerializedQuery < ActiveRecord::Base  #:nodoc:
-  serialize :query
+  serialize :query, coder: JSON
 
   validates_uniqueness_of :name, scope: :grid_name, on: :create, message: 'A query with this name already exists'
 


### PR DESCRIPTION
Fixes the below error seen in Rails 7.1 by using the JSON coder to serialize queries in WiceGridSerializedQuery.

```
serialize: missing keyword: :coder If no default coder is configured, a coder must be provided to `serialize`
```

```
/cache/bundle/ruby/3.0.0/gems/activerecord-7.1.4.2/lib/active_record/attribute_methods/serialization.rb:208:in `serialize': missing keyword: :coder If no default coder is configured, a coder must be provided to `serialize`. (ArgumentError)
	from /cache/bundle/ruby/3.0.0/bundler/gems/wice_grid-0716017344d8/lib/wice/wice_grid_serialized_query.rb:2:in `<class:WiceGridSerializedQuery>'
	from /cache/bundle/ruby/3.0.0/bundler/gems/wice_grid-0716017344d8/lib/wice/wice_grid_serialized_query.rb:1:in `<top (required)>'
	from /cache/bundle/ruby/3.0.0/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require'
	from /cache/bundle/ruby/3.0.0/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require'
	from /cache/bundle/ruby/3.0.0/bundler/gems/wice_grid-0716017344d8/lib/wice_grid.rb:40:in `on_action_view_load'
	from /cache/bundle/ruby/3.0.0/bundler/gems/wice_grid-0716017344d8/lib/wice_grid.rb:58:in `block (2 levels) in <class:WiceGridEngine>'
	from /cache/bundle/ruby/3.0.0/gems/activesupport-7.1.4.2/lib/active_support/lazy_load_hooks.rb:97:in `class_eval'
	from /cache/bundle/ruby/3.0.0/gems/activesupport-7.1.4.2/lib/active_support/lazy_load_hooks.rb:97:in `block in execute_hook'
	from /cache/bundle/ruby/3.0.0/gems/activesupport-7.1.4.2/lib/active_support/lazy_load_hooks.rb:87:in `with_execution_control'
	from /cache/bundle/ruby/3.0.0/gems/activesupport-7.1.4.2/lib/active_support/lazy_load_hooks.rb:92:in `execute_hook'
	from /cache/bundle/ruby/3.0.0/gems/activesupport-7.1.4.2/lib/active_support/lazy_load_hooks.rb:62:in `block in on_load'
	from /cache/bundle/ruby/3.0.0/gems/activesupport-7.1.4.2/lib/active_support/lazy_load_hooks.rb:61:in `each'
	from /cache/bundle/ruby/3.0.0/gems/activesupport-7.1.4.2/lib/active_support/lazy_load_hooks.rb:61:in `on_load'
	from /cache/bundle/ruby/3.0.0/bundler/gems/wice_grid-0716017344d8/lib/wice_grid.rb:57:in `block in <class:WiceGridEngine>'
	from /cache/bundle/ruby/3.0.0/gems/railties-7.1.4.2/lib/rails/initializable.rb:32:in `instance_exec'
	from /cache/bundle/ruby/3.0.0/gems/railties-7.1.4.2/lib/rails/initializable.rb:32:in `run'
	from /cache/bundle/ruby/3.0.0/gems/railties-7.1.4.2/lib/rails/initializable.rb:61:in `block in run_initializers'
	from /usr/local/rvm/rubies/ruby-3.0.6/lib/ruby/3.0.0/tsort.rb:228:in `block in tsort_each'
	from /usr/local/rvm/rubies/ruby-3.0.6/lib/ruby/3.0.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	from /usr/local/rvm/rubies/ruby-3.0.6/lib/ruby/3.0.0/tsort.rb:431:in `each_strongly_connected_component_from'
	from /usr/local/rvm/rubies/ruby-3.0.6/lib/ruby/3.0.0/tsort.rb:349:in `block in each_strongly_connected_component'
	from /usr/local/rvm/rubies/ruby-3.0.6/lib/ruby/3.0.0/tsort.rb:347:in `each'
	from /usr/local/rvm/rubies/ruby-3.0.6/lib/ruby/3.0.0/tsort.rb:347:in `call'
	from /usr/local/rvm/rubies/ruby-3.0.6/lib/ruby/3.0.0/tsort.rb:347:in `each_strongly_connected_component'
	from /usr/local/rvm/rubies/ruby-3.0.6/lib/ruby/3.0.0/tsort.rb:226:in `tsort_each'
	from /usr/local/rvm/rubies/ruby-3.0.6/lib/ruby/3.0.0/tsort.rb:205:in `tsort_each'
	from /cache/bundle/ruby/3.0.0/gems/railties-7.1.4.2/lib/rails/initializable.rb:60:in `run_initializers'
	from /cache/bundle/ruby/3.0.0/gems/railties-7.1.4.2/lib/rails/application.rb:426:in `initialize!'
	from /app/config/environment.rb:8:in `<top (required)>'
	from /cache/bundle/ruby/3.0.0/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require'
	from /cache/bundle/ruby/3.0.0/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require'
	from /cache/bundle/ruby/3.0.0/gems/railties-7.1.4.2/lib/rails/application.rb:402:in `require_environment!'
	from /cache/bundle/ruby/3.0.0/gems/railties-7.1.4.2/lib/rails/command/actions.rb:20:in `boot_application!'
	from /cache/bundle/ruby/3.0.0/gems/railties-7.1.4.2/lib/rails/commands/console/console_command.rb:105:in `perform'
	from /cache/bundle/ruby/3.0.0/gems/thor-1.3.2/lib/thor/command.rb:28:in `run'
	from /cache/bundle/ruby/3.0.0/gems/thor-1.3.2/lib/thor/invocation.rb:127:in `invoke_command'
	from /cache/bundle/ruby/3.0.0/gems/railties-7.1.4.2/lib/rails/command/base.rb:178:in `invoke_command'
	from /cache/bundle/ruby/3.0.0/gems/thor-1.3.2/lib/thor.rb:538:in `dispatch'
	from /cache/bundle/ruby/3.0.0/gems/railties-7.1.4.2/lib/rails/command/base.rb:73:in `perform'
	from /cache/bundle/ruby/3.0.0/gems/railties-7.1.4.2/lib/rails/command.rb:71:in `block in invoke'
	from /cache/bundle/ruby/3.0.0/gems/railties-7.1.4.2/lib/rails/command.rb:149:in `with_argv'
	from /cache/bundle/ruby/3.0.0/gems/railties-7.1.4.2/lib/rails/command.rb:69:in `invoke'
	from /cache/bundle/ruby/3.0.0/gems/railties-7.1.4.2/lib/rails/commands.rb:18:in `<top (required)>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'
```